### PR TITLE
Jenkins Dockerfiles

### DIFF
--- a/jenkins/crmprtd_tests/python35/Dockerfile
+++ b/jenkins/crmprtd_tests/python35/Dockerfile
@@ -4,3 +4,9 @@ RUN apt-get update -y \
     && apt-get install -y \
         postgresql \
         postgis
+
+RUN useradd -ms /bin/bash -u 1000 pythontest
+
+RUN chmod -R 777 /usr/local/
+
+USER pythontest

--- a/jenkins/crmprtd_tests/python36/Dockerfile
+++ b/jenkins/crmprtd_tests/python36/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.6
+
+RUN apt-get update -y \
+    && apt-get install -y \
+        postgresql \
+        postgis
+
+RUN useradd -ms /bin/bash -u 1000 pythontest
+
+RUN chmod -R 777 /usr/local/
+
+USER pythontest

--- a/jenkins/crmprtd_tests/python37/Dockerfile
+++ b/jenkins/crmprtd_tests/python37/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.7
+
+RUN apt-get update -y \
+    && apt-get install -y \
+        postgresql \
+        postgis
+
+RUN useradd -ms /bin/bash -u 1000 pythontest
+
+RUN chmod -R 777 /usr/local/
+
+USER pythontest

--- a/jenkins/python35-postgres-postgis/Dockerfile
+++ b/jenkins/python35-postgres-postgis/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.5
+
+RUN apt-get update -y \
+    && apt-get install -y \
+        postgresql \
+        postgis


### PR DESCRIPTION
These `Dockerfiles` are used by `crmprtd` to run the python test suite.  In the future any other custom `Dockerfiles` used by Jenkins will go into the `jenkins/` directory.

Edit: Add slash to directory